### PR TITLE
设置默认厂商推送策略为不论现线或者离线都通过第三方厂商通道下发

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.sensorsdata.focus</groupId>
-    <artifactId>sf-channel-push-getui</artifactId>
-    <version>0.1.4</version>
+    <artifactId>sf-channel-push-getui-canva</artifactId>
+    <version>0.1.5</version>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <repositories>
         <repository>
             <id>getui-nexus</id>
-            <url>http://mvn.gt.igexin.com/nexus/content/repositories/releases/</url>
+            <url>http://mvn.gt.getui.com/nexus/content/repositories/releases/</url>
         </repository>
     </repositories>
 
@@ -49,13 +49,7 @@
         <dependency>
             <groupId>com.gexin.platform</groupId>
             <artifactId>gexin-rp-sdk-http</artifactId>
-            <version>4.1.0.5</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.gexin.platform</groupId>
-            <artifactId>gexin-rp-fastjson</artifactId>
-            <version>1.0.0.7</version>
+            <version>4.1.2.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.gexin.platform</groupId>
+            <artifactId>gexin-rp-fastjson</artifactId>
+            <version>1.0.0.7</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.28</version>

--- a/src/main/java/cn/sensorsdata/focus/channel/GetuiClient.java
+++ b/src/main/java/cn/sensorsdata/focus/channel/GetuiClient.java
@@ -108,6 +108,9 @@ public class GetuiClient extends ChannelClient {
         message.setOffline(true);
         message.setOfflineExpireTime(MESSAGE_OFFLINE_EXPIRE_TIME);
 
+        // 设置默认厂商推送策略为不论现线或者离线都通过第三方厂商通道下发
+        message.setStrategyJson("{\"default\":2}");
+
         singleMessageBatch.add(Pair.of(message, messagingTask));
         log.debug("add push task into batch. [task='{}']", messagingTask);
 

--- a/src/main/java/cn/sensorsdata/focus/channel/GetuiClient.java
+++ b/src/main/java/cn/sensorsdata/focus/channel/GetuiClient.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.gexin.fastjson.JSONObject;
 import com.gexin.rp.sdk.base.IBatch;
 import com.gexin.rp.sdk.base.IPushResult;
+import com.gexin.rp.sdk.base.IPacket;
 import com.gexin.rp.sdk.base.impl.ListMessage;
 import com.gexin.rp.sdk.base.impl.SingleMessage;
 import com.gexin.rp.sdk.base.impl.Target;

--- a/src/main/java/cn/sensorsdata/focus/channel/GetuiClient.java
+++ b/src/main/java/cn/sensorsdata/focus/channel/GetuiClient.java
@@ -130,6 +130,9 @@ public class GetuiClient extends ChannelClient {
         // 离线有效时间，单位为毫秒，可选
         message.setOfflineExpireTime(MESSAGE_OFFLINE_EXPIRE_TIME);
 
+        // 设置默认厂商推送策略为不论现线或者离线都通过第三方厂商通道下发
+        message.setStrategyJson("{\"default\":2}");
+
         String failReason = null;
         try {
           // http://docs.getui.com/getui/server/java/push/

--- a/src/test/java/cn/sensorsdata/focus/channel/GetuiClientTest.java
+++ b/src/test/java/cn/sensorsdata/focus/channel/GetuiClientTest.java
@@ -16,7 +16,6 @@
 
 package cn.sensorsdata.focus.channel;
 
-import com.sensorsdata.focus.channel.entry.LandingType;
 import com.sensorsdata.focus.channel.entry.MessagingTask;
 import com.sensorsdata.focus.channel.entry.PushTask;
 
@@ -25,7 +24,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,11 +31,12 @@ import java.util.Map;
 public class GetuiClientTest extends TestCase {
 
   // 个推账号
-  private static final String APP_ID = "aaaaaaaaaaaaaaaaaaaaaa";
-  private static final String APP_KEY = "bbbbbbbbbbbbbbbbbbbbbb";
-  private static final String MASTER_SECRET = "cccccccccccccccccccccc";
+  private static final String APP_ID = "";
+  private static final String APP_KEY = "";
+  private static final String MASTER_SECRET = "";
   // 测试设备的推送 ID
-  private static final String CLIENT_ID = "dddddddddddddddddddddddddddddddd";
+  private static final String CLIENT_ID = "";  // canva-android
+//  private static final String CLIENT_ID = ""; // canva-IOS
 
   @Test
   @Ignore
@@ -46,29 +45,46 @@ public class GetuiClientTest extends TestCase {
     getuiChannelConfig.setAppId(APP_ID);
     getuiChannelConfig.setAppKey(APP_KEY);
     getuiChannelConfig.setMasterSecret(MASTER_SECRET);
+    getuiChannelConfig.setIntentTemplate("intent:#Intent;action=android.intent.action.oppopush;package=cn.canva.editor;component=cn.canva.editor/com.canva.app.editor.inappmessage.GetuiPushActivity;S.key={\"webUrl\":\"{sf_customized.webUrl}\",\"analyticPushId\":\"{sf_customized.analyticPushId}\",\"action2\":\"{sf_customized.action2}\"};end");
 
     List<MessagingTask> messagingTaskList = new ArrayList<>();
-    for (int i=0; i<3; i++){
 
-      PushTask pushTask = new PushTask();
-      pushTask.setLandingType(LandingType.CUSTOMIZED);
-      Map<String, String> testMap = new LinkedHashMap<>();
-      testMap.put("aaa", "bb");
-      pushTask.setCustomized(testMap);
-      pushTask.setMsgContent("content111"+i);
-      pushTask.setMsgTitle("title123");
-      pushTask.setClientId(CLIENT_ID);
-      MessagingTask messagingTask = new MessagingTask();
-      messagingTask.setPushTask(pushTask);
-      messagingTaskList.add(messagingTask);
-      messagingTaskList.add(messagingTask);
-    }
+    PushTask pushTask = new PushTask();
+
+    // 测试OPEN_APP
+//    pushTask.setLandingType(LandingType.OPEN_APP);
+//    pushTask.setSfData("{\"customized\":{},\"sf_landing_type\":\"OPEN_APP\",\"sf_msg_id\":\"b205ab0d-8606-42a8-8617-97042508d396\",\"sf_plan_id\":\"-1\",\"sf_audience_id\":\"-1\",\"sf_plan_strategy_id\":\"-1\",\"sf_strategy_unit_id\":null,\"sf_plan_type\":\"运营计划\"})");
+
+    // 测试 LINK
+//    pushTask.setLandingType(LandingType.LINK);
+//    pushTask.setLinkUrl("https://www.baidu.com");
+//    pushTask.setSfData("{\"customized\":{},\"sf_link_url\":\"https://www.baidu.com\",\"sf_landing_type\":\"LINK\",\"sf_msg_id\":\"e8fe3077-b9ca-4d83-a288-83eeb69d5f67\",\"sf_plan_id\":\"-1\",\"sf_audience_id\":\"-1\",\"sf_plan_strategy_id\":\"-1\",\"sf_strategy_unit_id\":null,\"sf_plan_type\":\"运营计划\"}");
+
+    // 测试 CUSTOMIZED
+//    pushTask.setLandingType(LandingType.CUSTOMIZED);
+    Map<String, String> testMap = new LinkedHashMap<>();
+    testMap.put("payload", "{\"action\":{\"action2\":\"search\",\"searchQuery2\":\"今日推荐\"}}");
+    testMap.put("webUrl", "https://www.canva.cn/search/templates?q=今日推荐");
+    testMap.put("analyticPushId", "20200721_test");
+    testMap.put("action2", "");
+    testMap.put("logoUrl", "https://wx4.sinaimg.cn/mw690/e04cc7a6gy1gfknluab27j20u00u0hdt.jpg");
+//    pushTask.setSfData("{\"customized\":{\"payload\":\"{\\\"action\\\":{\\\"action2\\\":\\\"search\\\",\\\"searchQuery2\\\":\\\"今日推荐\\\"}}\",\"webUrl\":\"https://www.canva.cn/search/templates?q=今日推荐\",\"analyticPushId\":\"20200721_test\",\"action2\":\"\",\"logoUrl\":\"https://wx4.sinaimg.cn/mw690/e04cc7a6gy1gfknluab27j20u00u0hdt.jpg\"},\"sf_landing_type\":\"CUSTOMIZED\",\"sf_msg_id\":\"755c2363-2dfe-4193-86b6-49692906d460\",\"sf_plan_id\":\"-1\",\"sf_audience_id\":\"-1\",\"sf_plan_strategy_id\":\"-1\",\"sf_strategy_unit_id\":null,\"sf_plan_type\":\"运营计划\"}");
+//    pushTask.setCustomized(testMap);
+
+
+    pushTask.setMsgContent("content123");
+    pushTask.setMsgTitle("title123");
+    pushTask.setClientId(CLIENT_ID);
+
+    MessagingTask messagingTask = new MessagingTask();
+    messagingTask.setPushTask(pushTask);
+    messagingTaskList.add(messagingTask);
 
     GetuiClient getuiClient = new GetuiClient();
     getuiClient.initChannelClient(getuiChannelConfig);
 
 
-    getuiClient.send(messagingTaskList);
+//    getuiClient.send(messagingTaskList);
     getuiClient.close();
   }
 }


### PR DESCRIPTION
个推 厂商推送策略 默认为
> 1: 表示该消息在用户在线时推送个推通道，用户离线时推送厂商通道;

这是为了个推在app运行时，能把渗透信息展示为弹窗。但这样导致app运行的时候，就没办法展示推送。 应该改为

> 2: 表示该消息只通过厂商通道策略下发，不考虑用户是否在线;

弹窗应该走 神策智能运营-> 弹窗计划